### PR TITLE
Fix missed userFullName key

### DIFF
--- a/faker.js
+++ b/faker.js
@@ -48,6 +48,7 @@ generateFakeData = async (userCount, blogsPerUser, commentsPerUser) => {
   //       new Comment({
   //         content: faker.lorem.sentence(),
   //         user,
+  //         userFullName: user.fullName,
   //         blog: blogs[index]._id,
   //       })
   //     );


### PR DESCRIPTION
faker.js의 주석 코드를 풀고, 실행시켰을 때, 
```
    userFullName: { type: String, required: true },
```
에러 나는 부분을 수정하였습니다.